### PR TITLE
ATO-70: Add 'Sorry, there is a problem' error page

### DIFF
--- a/src/app.constants.ts
+++ b/src/app.constants.ts
@@ -1,8 +1,12 @@
 export enum LOCALE {
     EN = "en",
     CY = "cy",
-};
+}
 
 export const HTTP_STATUS_CODES = {
-    NOT_FOUND: 404
+    NOT_FOUND: 404,
+    INTERNAL_SERVER_ERROR: 500,
+};
+export const PATH_NAMES = {
+    ERROR_PAGE: "/error",
 };

--- a/src/app.ts
+++ b/src/app.ts
@@ -6,6 +6,8 @@ import i18next from "i18next";
 import Backend from "i18next-fs-backend";
 import {i18nextConfigurationOptions} from "./config/i18next";
 import i18nextMiddleware from "i18next-http-middleware";
+import {PATH_NAMES} from "./app.constants";
+import {errorPageGet} from "./components/errors/error-controller";
 
 const APP_VIEWS = [
     path.join(__dirname, "components"),
@@ -34,6 +36,7 @@ async function createApp(): Promise<express.Application> {
 
     app.use(i18nextMiddleware.handle(i18next));
 
+    app.get(PATH_NAMES.ERROR_PAGE, errorPageGet);
     app.use(pageNotFoundHandler);
 
     return app;

--- a/src/components/errors/500.njk
+++ b/src/components/errors/500.njk
@@ -1,0 +1,12 @@
+{% extends "layout/base.njk" %}
+
+{% set pageTitleName = 'error.error500.title' | translate %}
+
+{% block content %}
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">{{ 'error.error500.header' | translate }}</h1>
+    <p class="govuk-body">{{ 'error.error500.content.paragraph1' | translate }}</p>
+  </div>
+</div>
+{% endblock %}

--- a/src/components/errors/error-controller.ts
+++ b/src/components/errors/error-controller.ts
@@ -1,0 +1,7 @@
+import { Request, Response } from "express";
+import { HTTP_STATUS_CODES } from "../../app.constants";
+
+export function errorPageGet(req: Request, res: Response): void {
+  res.status(HTTP_STATUS_CODES.INTERNAL_SERVER_ERROR);
+  res.render("errors/500.njk");
+}

--- a/src/components/errors/tests/error-controller.test.ts
+++ b/src/components/errors/tests/error-controller.test.ts
@@ -1,0 +1,32 @@
+import {expect, sinon} from "../../../../test/utils/test-utils";
+import {NextFunction, Request, Response} from "express";
+import {errorPageGet} from "../error-controller";
+import {mockRequest, mockResponse} from "mock-req-res";
+
+describe("errorController", () => {
+    let req: Request;
+    let res: Response;
+    let next: NextFunction;
+
+    beforeEach(() => {
+        req = mockRequest();
+        res = mockResponse();
+        next = sinon.spy();
+
+        errorPageGet(req, res);
+    });
+
+    afterEach(() => {
+        sinon.restore();
+    });
+
+    it("should render 500 template if page not found", () => {
+        const expectedTemplate = "errors/500.njk";
+
+        expect(res.render).to.have.been.calledOnceWith(expectedTemplate);
+    });
+
+    it("should return a 500 status code if page not found", () => {
+        expect(res.status).to.have.been.calledOnceWith(500);
+    });
+});

--- a/src/handlers/page-not-found-handler.ts
+++ b/src/handlers/page-not-found-handler.ts
@@ -1,5 +1,5 @@
-import { NextFunction, Request, Response } from "express";
-import { HTTP_STATUS_CODES } from "../app.constants";
+import {NextFunction, Request, Response} from "express";
+import {HTTP_STATUS_CODES} from "../app.constants";
 
 export function pageNotFoundHandler(
     req: Request,

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -112,6 +112,13 @@
         "govUKHomepageButtonHref": "https://www.gov.uk/",
         "govUKHomepageButtonText": "Ewch i hafan GOV.UK"
       }
+    },
+    "error500": {
+      "title": "Mae problem gyda’r gwasanaeth hwn",
+      "header": "Mae’n ddrwg gennym, mae problem",
+      "content": {
+        "paragraph1": "Rhowch gynnig arall yn nes ymlaen."
+      }
     }
   }
 }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -112,6 +112,13 @@
         "govUKHomepageButtonHref": "https://www.gov.uk/",
         "govUKHomepageButtonText": "Go to the GOV.UK homepage"
       }
+    },
+    "error500": {
+      "title": "There’s a problem with this service",
+      "header": "Sorry, there is a problem",
+      "content": {
+        "paragraph1": "Try again later."
+      }
     }
   }
 }

--- a/src/locales/tests/translations.test.ts
+++ b/src/locales/tests/translations.test.ts
@@ -6,27 +6,47 @@ describe("translations", () => {
 
     const testData = [
         {
+            path: "404",
+            errorCode: 404,
             language: "English",
             cookie: "en",
             expectedTitle: "Page not found",
             expectedParagraph1: "We cannot find the page you’re looking for."
         },
         {
+            path: "404",
+            errorCode: 404,
             language: "Welsh",
             cookie: "cy",
             expectedTitle: "Tudalen heb ei darganfod",
             expectedParagraph1: "Ni allwn ddod o hyd i’r dudalen rydych chi’n chwilio amdani."
+        },
+        {
+            path: "error",
+            errorCode: 500,
+            language: "English",
+            cookie: "en",
+            expectedTitle: "There’s a problem with this service",
+            expectedParagraph1: "Try again later."
+        },
+        {
+            path: "error",
+            errorCode: 500,
+            language: "Welsh",
+            cookie: "cy",
+            expectedTitle: "Mae problem gyda’r gwasanaeth hwn",
+            expectedParagraph1: "Rhowch gynnig arall yn nes ymlaen."
         }
     ]
 
-    itParam("should render 404 template in ${value.language} if ${value.cookie} cookie is present", testData, (done: Mocha.Done, value: any) => {
+    itParam("should render ${value.path} template in ${value.language} if ${value.cookie} cookie is present", testData, (done: Mocha.Done, value: any) => {
         createApp().then(app => {
             request(app)
-                .get("/404")
+                .get(`/${value.path}`)
                 .set("Cookie", `lng=${value.cookie};`)
                 .expect(new RegExp(value.expectedTitle))
                 .expect(new RegExp(value.expectedParagraph1))
-                .expect(404, done)
+                .expect(value.errorCode, done)
 
         })
     });


### PR DESCRIPTION
## What?

Add  an error page for Orchestration to display when it experiences 500s or other unexpected errors.

## Why?

Orchestration will need a frontend page to display to the user in the result of unexpected errors. Currently we redirect to the error page in the Authentication frontend but we want to decouple Orchestration completely from Authentication 

## Changes

- Add error page (500)
- Add relevant translations to translation.json files
- Write tests for error page and corresponding translations