### PR TITLE
ATO-NONE: Error page routing

### DIFF
--- a/src/app.constants.ts
+++ b/src/app.constants.ts
@@ -20,6 +20,7 @@ export const OIDC_ERRORS = {
 
 export const PATH_NAMES = {
   PROVE_IDENTITY_CALLBACK: "/ipv-callback",
-  PROVE_IDENTITY_CALLBACK_SESSION_EXPIRY_ERROR: "/ipv-callback-session-expiry-error",
+  PROVE_IDENTITY_CALLBACK_SESSION_EXPIRY_ERROR:
+    "/ipv-callback-session-expiry-error",
   ERROR_PAGE: "/error",
 };

--- a/src/app.ts
+++ b/src/app.ts
@@ -7,11 +7,12 @@ import i18next from "i18next";
 import Backend from "i18next-fs-backend";
 import { i18nextConfigurationOptions } from "./config/i18next";
 import i18nextMiddleware from "i18next-http-middleware";
-import { PATH_NAMES } from "./app.constants";
-import { errorPageGet } from "./components/errors/error-controller";
 import { proveIdentityCallbackRouter } from "./components/prove-identity-callback/prove-identity-callback-routes";
 import { noCacheMiddleware } from "./middleware/no-cache-middleware";
 import { getSessionIdMiddleware } from "./middleware/session-middleware";
+import { serverErrorHandler } from "./handlers/internal-server-error-handler";
+import { errorPageGet } from "./components/errors/error-controller";
+import { PATH_NAMES } from "./app.constants";
 
 const APP_VIEWS = [
   path.join(__dirname, "components"),
@@ -47,6 +48,7 @@ async function createApp(): Promise<express.Application> {
 
   app.use(proveIdentityCallbackRouter);
   app.get(PATH_NAMES.ERROR_PAGE, errorPageGet);
+  app.use(serverErrorHandler);
   app.use(pageNotFoundHandler);
 
   return app;

--- a/src/components/errors/error-controller.ts
+++ b/src/components/errors/error-controller.ts
@@ -1,10 +1,7 @@
 import { Request, Response } from "express";
 import { HTTP_STATUS_CODES } from "../../app.constants";
 
-export function errorPageGet(
-  req: Request,
-  res: Response,
-): void {
+export function errorPageGet(req: Request, res: Response): void {
   res.status(HTTP_STATUS_CODES.INTERNAL_SERVER_ERROR);
   res.render("errors/500.njk");
 }

--- a/src/components/errors/error-controller.ts
+++ b/src/components/errors/error-controller.ts
@@ -1,7 +1,10 @@
 import { Request, Response } from "express";
 import { HTTP_STATUS_CODES } from "../../app.constants";
 
-export function errorPageGet(req: Request, res: Response): void {
+export function errorPageGet(
+  req: Request,
+  res: Response,
+): void {
   res.status(HTTP_STATUS_CODES.INTERNAL_SERVER_ERROR);
   res.render("errors/500.njk");
 }

--- a/src/components/errors/tests/error-controller.test.ts
+++ b/src/components/errors/tests/error-controller.test.ts
@@ -18,13 +18,13 @@ describe("errorController", () => {
     sinon.restore();
   });
 
-  it("should render 500 template if page not found", () => {
+  it("should render 500 template if internal server error", () => {
     const expectedTemplate = "errors/500.njk";
 
     expect(res.render).to.have.been.calledOnceWith(expectedTemplate);
   });
 
-  it("should return a 500 status code if page not found", () => {
+  it("should return a 500 status code if internal server error", () => {
     expect(res.status).to.have.been.calledOnceWith(500);
   });
 });

--- a/src/components/prove-identity-callback/oidc-api-service.ts
+++ b/src/components/prove-identity-callback/oidc-api-service.ts
@@ -1,3 +1,6 @@
-export function getAuthCodeRedirectUri(sessionId: string, clientSessionId: string): string {
+export function getAuthCodeRedirectUri(
+  sessionId: string,
+  clientSessionId: string
+): string {
   return "https://mock-successful-redirect.gov.uk";
 }

--- a/src/components/prove-identity-callback/prove-identity-callback-controller.ts
+++ b/src/components/prove-identity-callback/prove-identity-callback-controller.ts
@@ -1,6 +1,9 @@
 import { Request, Response } from "express";
 import { ExpressRouteFunc } from "../../types";
-import { IdentityProcessingStatus, ProveIdentityCallbackServiceInterface } from "./types";
+import {
+  IdentityProcessingStatus,
+  ProveIdentityCallbackServiceInterface,
+} from "./types";
 import { IPV_ERROR_CODES, OIDC_ERRORS } from "../../app.constants";
 import { createServiceRedirectErrorUrl } from "../../utils/error";
 import { proveIdentityCallbackService } from "./prove-identity-callback-service";
@@ -27,7 +30,6 @@ export function proveIdentityCallbackGet(
     if (response.data.status === IdentityProcessingStatus.COMPLETED) {
       // TODO: Get auth token from oidc-api (AuthCodeHandler)
       redirectPath = getAuthCodeRedirectUri(sessionId, clientSessionId);
-
     } else {
       redirectPath = createServiceRedirectErrorUrl(
         response.data.redirectUri,

--- a/src/components/prove-identity-callback/prove-identity-callback-service.ts
+++ b/src/components/prove-identity-callback/prove-identity-callback-service.ts
@@ -1,25 +1,32 @@
 import { ApiResponseResult } from "../../types";
-import { IdentityProcessingStatus, ProcessIdentityResponse, ProveIdentityCallbackServiceInterface } from "./types";
+import {
+  IdentityProcessingStatus,
+  ProcessIdentityResponse,
+  ProveIdentityCallbackServiceInterface,
+} from "./types";
 
 export function proveIdentityCallbackService(): ProveIdentityCallbackServiceInterface {
-  const identityProcessed = async function (): Promise<ApiResponseResult<ProcessIdentityResponse>> {
+  const identityProcessed = async function (): Promise<
+    ApiResponseResult<ProcessIdentityResponse>
+  > {
     return {
       data: {
         message: "mock",
         code: -1,
         clientName: "mockClient",
         redirectUri: "https://mock-successful-redirect.gov.uk",
-        status: Math.random() < 0.5
-          ? IdentityProcessingStatus.PROCESSING
-          : Math.random() < 0.95
+        status:
+          Math.random() < 0.5
+            ? IdentityProcessingStatus.PROCESSING
+            : Math.random() < 0.95
             ? IdentityProcessingStatus.COMPLETED
             : IdentityProcessingStatus.ERROR,
-        state: "mockState"
+        state: "mockState",
       },
-      success: true
-    }
-  }
+      success: true,
+    };
+  };
   return {
-    processIdentity: identityProcessed
-  }
+    processIdentity: identityProcessed,
+  };
 }

--- a/src/components/prove-identity-callback/tests/prove-identity-callback-controller.test.ts
+++ b/src/components/prove-identity-callback/tests/prove-identity-callback-controller.test.ts
@@ -4,13 +4,22 @@ import { describe } from "mocha";
 import { sinon } from "../../../../test/utils/test-utils";
 import { Request, Response } from "express";
 
-import { IPV_ERROR_CODES, OIDC_ERRORS, } from "../../../app.constants";
-import { mockRequest, mockResponse, RequestOutput, ResponseOutput, } from "mock-req-res";
+import { IPV_ERROR_CODES, OIDC_ERRORS } from "../../../app.constants";
+import {
+  mockRequest,
+  mockResponse,
+  RequestOutput,
+  ResponseOutput,
+} from "mock-req-res";
 import {
   proveIdentityCallbackGet,
-  proveIdentityCallbackSessionExpiryError
+  proveIdentityCallbackSessionExpiryError,
 } from "../prove-identity-callback-controller";
-import { IdentityProcessingStatus, ProcessIdentityResponse, ProveIdentityCallbackServiceInterface, } from "../types";
+import {
+  IdentityProcessingStatus,
+  ProcessIdentityResponse,
+  ProveIdentityCallbackServiceInterface,
+} from "../types";
 import { ApiResponseResult } from "../../../types";
 
 describe("prove identity callback controller", () => {
@@ -24,7 +33,9 @@ describe("prove identity callback controller", () => {
   describe("proveIdentityCallbackGet", () => {
     it("should redirect to auth code when identity processing complete", async () => {
       const fakeProveIdentityService: ProveIdentityCallbackServiceInterface = {
-        processIdentity: sinon.fake.returns(mockProcessIdentity(IdentityProcessingStatus.COMPLETED)),
+        processIdentity: sinon.fake.returns(
+          mockProcessIdentity(IdentityProcessingStatus.COMPLETED)
+        ),
       } as unknown as ProveIdentityCallbackServiceInterface;
 
       await proveIdentityCallbackGet(fakeProveIdentityService)(
@@ -32,12 +43,16 @@ describe("prove identity callback controller", () => {
         res as Response
       );
 
-      expect(res.redirect).to.have.been.calledWith("https://mock-successful-redirect.gov.uk");
+      expect(res.redirect).to.have.been.calledWith(
+        "https://mock-successful-redirect.gov.uk"
+      );
     });
 
     it("should render index when identity is being processed ", async () => {
       const fakeProveIdentityService: ProveIdentityCallbackServiceInterface = {
-        processIdentity: sinon.fake.returns(mockProcessIdentity(IdentityProcessingStatus.PROCESSING)),
+        processIdentity: sinon.fake.returns(
+          mockProcessIdentity(IdentityProcessingStatus.PROCESSING)
+        ),
       } as unknown as ProveIdentityCallbackServiceInterface;
 
       await proveIdentityCallbackGet(fakeProveIdentityService)(
@@ -52,7 +67,9 @@ describe("prove identity callback controller", () => {
 
     it("should redirect to error page when identity processing has errored", async () => {
       const fakeProveIdentityService: ProveIdentityCallbackServiceInterface = {
-        processIdentity: sinon.fake.returns(mockProcessIdentity(IdentityProcessingStatus.ERROR)),
+        processIdentity: sinon.fake.returns(
+          mockProcessIdentity(IdentityProcessingStatus.ERROR)
+        ),
       } as unknown as ProveIdentityCallbackServiceInterface;
 
       await proveIdentityCallbackGet(fakeProveIdentityService)(
@@ -70,7 +87,9 @@ describe("prove identity callback controller", () => {
     });
   });
 
-  function mockProcessIdentity(status: IdentityProcessingStatus): ApiResponseResult<ProcessIdentityResponse> {
+  function mockProcessIdentity(
+    status: IdentityProcessingStatus
+  ): ApiResponseResult<ProcessIdentityResponse> {
     return {
       data: {
         message: "test",
@@ -78,15 +97,16 @@ describe("prove identity callback controller", () => {
         clientName: "testClient",
         redirectUri: "http://someservice.com/auth",
         status: status,
-        state: "testState"
+        state: "testState",
       },
-      success: true
-    }
+      success: true,
+    };
   }
 
   describe("proveIdentityCallbackSessionExpiryError", () => {
     it("should redirect to error page when callback session expires", () => {
-      const expectedTemplate = "prove-identity-callback/session-expiry-error.njk";
+      const expectedTemplate =
+        "prove-identity-callback/session-expiry-error.njk";
 
       proveIdentityCallbackSessionExpiryError(req, res);
 

--- a/src/components/prove-identity-callback/tests/prove-identity-callback-controller.test.ts
+++ b/src/components/prove-identity-callback/tests/prove-identity-callback-controller.test.ts
@@ -14,8 +14,8 @@ import { IdentityProcessingStatus, ProcessIdentityResponse, ProveIdentityCallbac
 import { ApiResponseResult } from "../../../types";
 
 describe("prove identity callback controller", () => {
-  let req: RequestOutput = mockRequest();
-  let res: ResponseOutput = mockResponse();
+  const req: RequestOutput = mockRequest();
+  const res: ResponseOutput = mockResponse();
 
   afterEach(() => {
     sinon.restore();

--- a/src/components/prove-identity-callback/types.ts
+++ b/src/components/prove-identity-callback/types.ts
@@ -1,13 +1,16 @@
 import { ApiResponseResult, DefaultApiResponse } from "../../types";
 
 export interface ProveIdentityCallbackServiceInterface {
-  processIdentity: (sessionId: string, clientSessionId: string) => Promise<ApiResponseResult<ProcessIdentityResponse>>;
+  processIdentity: (
+    sessionId: string,
+    clientSessionId: string
+  ) => Promise<ApiResponseResult<ProcessIdentityResponse>>;
 }
 
 export interface ProcessIdentityResponse extends DefaultApiResponse {
-  clientName?: string,
-  redirectUri: string,
-  status: IdentityProcessingStatus
+  clientName?: string;
+  redirectUri: string;
+  status: IdentityProcessingStatus;
   state?: string;
 }
 

--- a/src/handlers/internal-server-error-handler.ts
+++ b/src/handlers/internal-server-error-handler.ts
@@ -1,0 +1,15 @@
+import { NextFunction, Request, Response } from "express";
+import { HTTP_STATUS_CODES } from "../app.constants";
+
+export function serverErrorHandler(
+  err: any,
+  req: Request,
+  res: Response,
+  next: NextFunction
+): void {
+  if (res.headersSent) {
+    return next(err);
+  }
+  res.status(HTTP_STATUS_CODES.INTERNAL_SERVER_ERROR);
+  res.render("errors/500.njk");
+}

--- a/src/handlers/tests/internal-server-error-handler.test.ts
+++ b/src/handlers/tests/internal-server-error-handler.test.ts
@@ -1,0 +1,50 @@
+import { expect, sinon } from "../../../test/utils/test-utils";
+import { NextFunction, Request, Response } from "express";
+import { mockRequest } from "mock-req-res";
+import { serverErrorHandler } from "../internal-server-error-handler";
+
+describe("errorController", () => {
+  let err: Error;
+  let req: Request;
+  let res: Response;
+  let next: NextFunction;
+
+  beforeEach(() => {
+    req = mockRequest();
+    res = {
+      headersSent: false,
+      statusCode: 200,
+      render: () => {
+      },
+      status: function (newStatus: number) {
+        this.statusCode = newStatus;
+      },
+    } as unknown as Response;
+    next = sinon.spy();
+  });
+
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it("should call next if headers have already been sent", () => {
+    res.headersSent = true;
+    const err = new Error("Test error");
+
+    serverErrorHandler(err, req, res, next);
+
+    expect(next).to.have.been.calledOnceWith(err);
+    expect(res.statusCode).to.equal(200);
+  });
+
+  it("should render 500 template if internal server error", () => {
+    const expectedTemplate = "errors/500.njk";
+    const renderSpy = sinon.spy(res, "render");
+
+    serverErrorHandler(err, req, res, next);
+
+    expect(renderSpy).to.have.been.calledOnceWith(expectedTemplate);
+    expect(res.statusCode).to.equal(500);
+  });
+});

--- a/src/handlers/tests/internal-server-error-handler.test.ts
+++ b/src/handlers/tests/internal-server-error-handler.test.ts
@@ -14,15 +14,13 @@ describe("errorController", () => {
     res = {
       headersSent: false,
       statusCode: 200,
-      render: () => {
-      },
+      render: () => {},
       status: function (newStatus: number) {
         this.statusCode = newStatus;
       },
     } as unknown as Response;
     next = sinon.spy();
   });
-
 
   afterEach(() => {
     sinon.restore();

--- a/src/locales/tests/translations.test.ts
+++ b/src/locales/tests/translations.test.ts
@@ -10,7 +10,7 @@ describe("translations", () => {
       language: "English",
       cookie: "en",
       expectedTitle: "Page not found",
-      expectedParagraphContent: "We cannot find the page you’re looking for."
+      expectedParagraphContent: "We cannot find the page you’re looking for.",
     },
     {
       path: "404",
@@ -18,7 +18,8 @@ describe("translations", () => {
       language: "Welsh",
       cookie: "cy",
       expectedTitle: "Tudalen heb ei darganfod",
-      expectedParagraphContent: "Ni allwn ddod o hyd i’r dudalen rydych chi’n chwilio amdani."
+      expectedParagraphContent:
+        "Ni allwn ddod o hyd i’r dudalen rydych chi’n chwilio amdani.",
     },
     {
       path: "error",
@@ -26,7 +27,7 @@ describe("translations", () => {
       language: "English",
       cookie: "en",
       expectedTitle: "There’s a problem with this service",
-      expectedParagraphContent: "Try again later."
+      expectedParagraphContent: "Try again later.",
     },
     {
       path: "error",
@@ -34,7 +35,7 @@ describe("translations", () => {
       language: "Welsh",
       cookie: "cy",
       expectedTitle: "Mae problem gyda’r gwasanaeth hwn",
-      expectedParagraphContent: "Rhowch gynnig arall yn nes ymlaen."
+      expectedParagraphContent: "Rhowch gynnig arall yn nes ymlaen.",
     },
     {
       path: "ipv-callback-session-expiry-error",
@@ -42,7 +43,8 @@ describe("translations", () => {
       language: "English",
       cookie: "en",
       expectedTitle: "Sorry, there is a problem",
-      expectedParagraphContent: "Go back to the service you were trying to use. You can look for the service using your search engine or find it from the GOV.UK homepage."
+      expectedParagraphContent:
+        "Go back to the service you were trying to use. You can look for the service using your search engine or find it from the GOV.UK homepage.",
     },
     {
       path: "ipv-callback-session-expiry-error",
@@ -50,19 +52,23 @@ describe("translations", () => {
       language: "Welsh",
       cookie: "cy",
       expectedTitle: "Mae’n ddrwg gennym, mae problem",
-      expectedParagraphContent: "Ewch yn ôl i’r gwasanaeth roeddech yn ceisio ei ddefnyddio. Gallwch chwilio am y gwasanaeth gan ddefnyddio eich peiriant chwilio neu dewch o hyd iddo o hafan GOV.UK."
+      expectedParagraphContent:
+        "Ewch yn ôl i’r gwasanaeth roeddech yn ceisio ei ddefnyddio. Gallwch chwilio am y gwasanaeth gan ddefnyddio eich peiriant chwilio neu dewch o hyd iddo o hafan GOV.UK.",
+    },
+  ];
+
+  itParam(
+    "should render ${value.path} template in ${value.language} if ${value.cookie} cookie is present",
+    testData,
+    (done: Mocha.Done, value: any) => {
+      createApp().then((app) => {
+        request(app)
+          .get(`/${value.path}`)
+          .set("Cookie", `lng=${value.cookie};`)
+          .expect(new RegExp(value.expectedTitle))
+          .expect(new RegExp(value.expectedParagraphContent))
+          .expect(value.errorCode, done);
+      });
     }
-  ]
-
-  itParam("should render ${value.path} template in ${value.language} if ${value.cookie} cookie is present", testData, (done: Mocha.Done, value: any) => {
-    createApp().then(app => {
-      request(app)
-        .get(`/${value.path}`)
-        .set("Cookie", `lng=${value.cookie};`)
-        .expect(new RegExp(value.expectedTitle))
-        .expect(new RegExp(value.expectedParagraphContent))
-        .expect(value.errorCode, done)
-
-    })
-  });
-})
+  );
+});

--- a/src/middleware/session-middleware.ts
+++ b/src/middleware/session-middleware.ts
@@ -31,5 +31,5 @@ export function validateSessionMiddleware(
   }
 
   res.status(HTTP_STATUS_CODES.UNAUTHORIZED);
-  res.redirect("/error")
+  res.redirect("/error");
 }

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -1,21 +1,21 @@
 export function createServiceRedirectErrorUrl(
-    redirectUri: string,
-    error: string,
-    errorDescription: string,
-    state: string
+  redirectUri: string,
+  error: string,
+  errorDescription: string,
+  state: string
 ): string {
-    const redirect = new URL(redirectUri);
-    const params = {
-        error: error,
-        error_description: errorDescription,
-        state: state,
-    };
+  const redirect = new URL(redirectUri);
+  const params = {
+    error: error,
+    error_description: errorDescription,
+    state: state,
+  };
 
-    return (
-        redirect +
-        "?" +
-        Object.entries(params)
-            .map(([key, value]) => `${key}=${encodeURIComponent(value)}`)
-            .join("&")
-    );
+  return (
+    redirect +
+    "?" +
+    Object.entries(params)
+      .map(([key, value]) => `${key}=${encodeURIComponent(value)}`)
+      .join("&")
+  );
 }


### PR DESCRIPTION
## What?

Add routing to the error page for when there is an error on the orchestration side. Linting has also been done

## Why?

So that the user sees a nice error page for if the orchestration side errors