### PR TITLE
ATO-180: Add Network Load Balancer and Application Load Balancer

### DIFF
--- a/deploy-sandpit.sh
+++ b/deploy-sandpit.sh
@@ -19,5 +19,5 @@ pushd "./infrastructure/sandpit/ecs"
 echo ${parameters}
 echo "Deploying ECS"
 sam build
-sam deploy --stack-name sandpit-orch-frontend-ecs --template-file template.yaml --parameter-overrides $parameters --no-fail-on-empty-changeset --capabilities CAPABILITY_IAM
+sam deploy --stack-name sandpit-orch-frontend --template-file template.yaml --parameter-overrides $parameters --no-fail-on-empty-changeset --capabilities CAPABILITY_IAM
 popd

--- a/infrastructure/sandpit/ecs/template.yaml
+++ b/infrastructure/sandpit/ecs/template.yaml
@@ -1,5 +1,5 @@
 Parameters:
-  Enviroment:
+  Environment:
     Type: String
   AWSAccount:
     Type: String
@@ -10,12 +10,12 @@ Resources:
   OrchECSCluster:
     Type: "AWS::ECS::Cluster"
     Properties:
-      ClusterName: !Sub ${Enviroment}-orch-app-cluster
+      ClusterName: !Sub ${Environment}-orch-app-cluster
 
   OrchECSLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
-      LogGroupName: !Sub /ecs/${Enviroment}-orch-frontend
+      LogGroupName: !Sub /ecs/${Environment}-orch-frontend
 
   OrchFrontendECSExecutionRole:
     Type: "AWS::IAM::Role"
@@ -33,9 +33,9 @@ Resources:
   OrchFrontendECSService:
     Type: AWS::ECS::Service
     Properties:
-      ServiceName: !Sub ${Enviroment}-orch-frontend-ecs-service
+      ServiceName: !Sub ${Environment}-orch-frontend-ecs-service
       Cluster: !Ref OrchECSCluster
-      TaskDefinition: !Ref OrchFontendTaskDefinition
+      TaskDefinition: !Ref OrchFrontendTaskDefinition
       DesiredCount: 1
       LaunchType: FARGATE
       NetworkConfiguration:
@@ -46,14 +46,10 @@ Resources:
             - subnet-01b7b1c835828eb3d
             - subnet-0b648700a8ac43736
           SecurityGroups:
-            - sg-0d571f01baff4379a
-            - sg-01607dd8a81407734
-            - sg-0bf931c1887e0cff7
-            - sg-0e45bfc8984bb6bd3
-  OrchFontendTaskDefinition:
+  OrchFrontendTaskDefinition:
     Type: AWS::ECS::TaskDefinition
     Properties:
-      Family: !Sub ${Enviroment}-orch-frontend-ecs-task-definition
+      Family: !Sub ${Environment}-orch-frontend-ecs-task-definition
       Cpu: 256
       Memory: 0.5GB
       NetworkMode: awsvpc

--- a/infrastructure/sandpit/ecs/template.yaml
+++ b/infrastructure/sandpit/ecs/template.yaml
@@ -7,6 +7,7 @@ Parameters:
     Type: String
 
 Resources:
+  # ECS
   OrchECSCluster:
     Type: "AWS::ECS::Cluster"
     Properties:
@@ -31,6 +32,7 @@ Resources:
         - "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
 
   OrchFrontendECSService:
+    DependsOn: OrchFrontendAlbListener
     Type: AWS::ECS::Service
     Properties:
       ServiceName: !Sub ${Environment}-orch-frontend-ecs-service
@@ -46,6 +48,12 @@ Resources:
             - subnet-01b7b1c835828eb3d
             - subnet-0b648700a8ac43736
           SecurityGroups:
+            - !Ref OrchFrontendECSTaskSecurityGroup
+      LoadBalancers:
+        - ContainerName: sandpit-orch-frontend-image
+          ContainerPort: 3000
+          TargetGroupArn: !Ref OrchFrontendAlbTargetGroup
+
   OrchFrontendTaskDefinition:
     Type: AWS::ECS::TaskDefinition
     Properties:
@@ -67,3 +75,79 @@ Resources:
               awslogs-group: !Ref OrchECSLogGroup
               awslogs-region: !Sub ${Region}
               awslogs-stream-prefix: ecs
+
+  # Application Load Balancer
+  OrchFrontendAlb:
+    Type: "AWS::ElasticLoadBalancingV2::LoadBalancer"
+    Properties:
+      Name: !Sub ${Environment}-orch-frontend-alb
+      Subnets:
+        - subnet-0027e271c35f828c1
+        - subnet-01b7b1c835828eb3d
+        - subnet-0b648700a8ac43736
+      SecurityGroups:
+        - !Ref OrchFrontendAlbSecurityGroup
+
+  OrchFrontendAlbTargetGroup:
+    Type: "AWS::ElasticLoadBalancingV2::TargetGroup"
+    Properties:
+      Name: !Sub ${Environment}-orch-frontend-alb-tg
+      Port: 3000
+      Protocol: HTTP
+      VpcId: vpc-0b6f4a5d72f84ed0c
+      TargetType: ip
+      HealthCheckProtocol: HTTP
+      HealthCheckPort: "traffic-port"
+      HealthCheckPath: "/health"
+      HealthCheckIntervalSeconds: 30
+      HealthyThresholdCount: 2
+      UnhealthyThresholdCount: 2
+      Matcher:
+        HttpCode: "200"
+
+  OrchFrontendAlbListener:
+    Type: "AWS::ElasticLoadBalancingV2::Listener"
+    Properties:
+      DefaultActions:
+        - Type: forward
+          TargetGroupArn: !Ref OrchFrontendAlbTargetGroup
+      LoadBalancerArn: !Ref OrchFrontendAlb
+      Port: 80
+      Protocol: HTTP
+
+  # Security Groups
+  OrchFrontendECSTaskSecurityGroup:
+    Type: "AWS::EC2::SecurityGroup"
+    Properties:
+      GroupDescription: "Security group for ECS Tasks"
+      VpcId: vpc-0b6f4a5d72f84ed0c
+      SecurityGroupIngress:
+        - IpProtocol: "tcp"
+          FromPort: 3000
+          ToPort: 3000
+          SourceSecurityGroupId: !Ref OrchFrontendAlbSecurityGroup
+      SecurityGroupEgress:
+        - IpProtocol: "-1"
+          FromPort: 0
+          ToPort: 65535
+          CidrIp: "0.0.0.0/0"
+
+  OrchFrontendAlbSecurityGroup:
+    Type: "AWS::EC2::SecurityGroup"
+    Properties:
+      GroupDescription: "Security group for OrchFrontendAlb"
+      VpcId: vpc-0b6f4a5d72f84ed0c
+      SecurityGroupIngress:
+        - IpProtocol: "tcp"
+          FromPort: 80
+          ToPort: 80
+          CidrIp: "0.0.0.0/0"
+        - IpProtocol: "tcp"
+          FromPort: 443
+          ToPort: 443
+          CidrIp: "0.0.0.0/0"
+      SecurityGroupEgress:
+        - IpProtocol: "-1"
+          FromPort: 0
+          ToPort: 65535
+          CidrIp: "0.0.0.0/0"

--- a/infrastructure/sandpit/ecs/template.yaml
+++ b/infrastructure/sandpit/ecs/template.yaml
@@ -154,58 +154,108 @@ Resources:
       Port: 80
       Protocol: TCP
 
-  # Security Groups
+  # Security Groups and Ingress / Egress rules
   OrchFrontendECSTaskSecurityGroup:
     Type: "AWS::EC2::SecurityGroup"
     Properties:
       GroupDescription: "Security group for ECS Tasks"
       VpcId: vpc-0b6f4a5d72f84ed0c
-      SecurityGroupIngress:
-        - IpProtocol: "tcp"
-          FromPort: 3000
-          ToPort: 3000
-          SourceSecurityGroupId: !Ref OrchFrontendAlbSecurityGroup
-      SecurityGroupEgress:
-        - IpProtocol: "-1"
-          FromPort: 0
-          ToPort: 65535
-          CidrIp: "0.0.0.0/0"
+
+  OrchFrontendECSTaskSecurityGroupIngress:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      IpProtocol: "tcp"
+      FromPort: 3000
+      ToPort: 3000
+      SourceSecurityGroupId:
+        Fn::GetAtt:
+          - OrchFrontendAlbSecurityGroup
+          - GroupId
+      GroupId:
+        Fn::GetAtt:
+          - OrchFrontendECSTaskSecurityGroup
+          - GroupId
+  
+  OrchFrontendECSTaskSecurityGroupEgress:
+    Type: AWS::EC2::SecurityGroupEgress
+    Properties:
+      IpProtocol: "-1"
+      FromPort: 0
+      ToPort: 65535
+      CidrIp: "0.0.0.0/0"
+      GroupId:
+        Fn::GetAtt:
+          - OrchFrontendECSTaskSecurityGroup
+          - GroupId
 
   OrchFrontendAlbSecurityGroup:
     Type: "AWS::EC2::SecurityGroup"
     Properties:
       GroupDescription: "Security group for OrchFrontendAlb"
       VpcId: vpc-0b6f4a5d72f84ed0c
-      SecurityGroupIngress:
-        - IpProtocol: "tcp"
-          FromPort: 80
-          ToPort: 80
-          CidrIp: "10.0.0.0/16"
-        - IpProtocol: "tcp"
-          FromPort: 3000
-          ToPort: 3000
-          CidrIp: "10.0.0.0/16"
-      SecurityGroupEgress:
-        - IpProtocol: "-1"
-          FromPort: 3000
-          ToPort: 3000
-          CidrIp: "10.0.0.0/16"
+
+  OrchFrontendAlbSecurityGroupIngress:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      IpProtocol: "tcp"
+      FromPort: 80
+      ToPort: 80
+      SourceSecurityGroupId:
+        Fn::GetAtt:
+          - OrchFrontendNlbSecurityGroup
+          - GroupId
+      GroupId:
+        Fn::GetAtt:
+          - OrchFrontendAlbSecurityGroup
+          - GroupId
+  
+  OrchFrontendAlbSecurityGroupEgress:
+    Type: AWS::EC2::SecurityGroupEgress
+    Properties:
+      IpProtocol: "-1"
+      FromPort: 3000
+      ToPort: 3000
+      DestinationSecurityGroupId:
+        Fn::GetAtt:
+          - OrchFrontendECSTaskSecurityGroup
+          - GroupId
+      GroupId:
+        Fn::GetAtt:
+          - OrchFrontendAlbSecurityGroup
+          - GroupId
 
   OrchFrontendNlbSecurityGroup:
     Type: "AWS::EC2::SecurityGroup"
     Properties:
       GroupDescription: "Security group for OrchFrontendNlb"
       VpcId: vpc-0b6f4a5d72f84ed0c
-      SecurityGroupIngress:
-        - IpProtocol: "tcp"
-          FromPort: 80
-          ToPort: 80
-          CidrIp: "0.0.0.0/0"
-      SecurityGroupEgress:
-        - IpProtocol: "-1"
-          FromPort: 80
-          ToPort: 80
-          SourceSecurityGroupId: !Ref OrchFrontendAlbSecurityGroup
+
+  OrchFrontendNlbSecurityGroupIngress:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      IpProtocol: "tcp"
+      FromPort: 80
+      ToPort: 80
+      CidrIp: "0.0.0.0/0"
+      GroupId:
+        Fn::GetAtt:
+          - OrchFrontendNlbSecurityGroup
+          - GroupId
+
+  OrchFrontendNlbSecurityGroupEgress:
+    Type: AWS::EC2::SecurityGroupEgress
+    Properties:
+      IpProtocol: "-1"
+      FromPort: 80
+      ToPort: 80
+      DestinationSecurityGroupId:
+        Fn::GetAtt:
+          - OrchFrontendAlbSecurityGroup
+          - GroupId
+      GroupId:
+        Fn::GetAtt:
+          - OrchFrontendNlbSecurityGroup
+          - GroupId
 
 Outputs:
   # OrchFrontendNlbDnsName and OrchFrontendNlbArn are used by the API Gateway (di-authentication-api) to define the NLB integration and VPC Link

--- a/infrastructure/sandpit/ecs/template.yaml
+++ b/infrastructure/sandpit/ecs/template.yaml
@@ -115,6 +115,45 @@ Resources:
       Port: 80
       Protocol: HTTP
 
+  # Network Load Balancer
+  OrchFrontendNlb:
+    Type: "AWS::ElasticLoadBalancingV2::LoadBalancer"
+    Properties:
+      Name: !Sub ${Environment}-orch-frontend-nlb
+      Type: network
+      Subnets:
+        - subnet-0027e271c35f828c1
+        - subnet-01b7b1c835828eb3d
+        - subnet-0b648700a8ac43736
+      SecurityGroups:
+        - !Ref OrchFrontendNlbSecurityGroup
+
+  OrchFrontendNlbTargetGroup:
+    Type: "AWS::ElasticLoadBalancingV2::TargetGroup"
+    Properties:
+      Name: !Sub ${Environment}-orch-frontend-nlb-tg
+      Port: 80
+      Protocol: TCP
+      VpcId: vpc-0b6f4a5d72f84ed0c
+      TargetType: alb
+      Targets:
+        - Id: !Ref OrchFrontendAlb
+      TargetType: alb
+      HealthCheckPort: "traffic-port"
+      HealthCheckIntervalSeconds: 30
+      HealthyThresholdCount: 2
+      UnhealthyThresholdCount: 2
+
+  OrchFrontendNlbListener:
+    Type: "AWS::ElasticLoadBalancingV2::Listener"
+    Properties:
+      DefaultActions:
+        - Type: forward
+          TargetGroupArn: !Ref OrchFrontendNlbTargetGroup
+      LoadBalancerArn: !Ref OrchFrontendNlb
+      Port: 80
+      Protocol: TCP
+
   # Security Groups
   OrchFrontendECSTaskSecurityGroup:
     Type: "AWS::EC2::SecurityGroup"
@@ -151,3 +190,34 @@ Resources:
           FromPort: 0
           ToPort: 65535
           CidrIp: "0.0.0.0/0"
+
+  OrchFrontendNlbSecurityGroup:
+    Type: "AWS::EC2::SecurityGroup"
+    Properties:
+      GroupDescription: "Security group for OrchFrontendNlb"
+      VpcId: vpc-0b6f4a5d72f84ed0c
+      SecurityGroupIngress:
+        - IpProtocol: "tcp"
+          FromPort: 80
+          ToPort: 80
+          CidrIp: "0.0.0.0/0"
+        - IpProtocol: "tcp"
+          FromPort: 443
+          ToPort: 443
+          CidrIp: "0.0.0.0/0"
+      SecurityGroupEgress:
+        - IpProtocol: "-1"
+          FromPort: 0
+          ToPort: 65535
+          CidrIp: "0.0.0.0/0"
+
+Outputs:
+  # OrchFrontendNlbDnsName and OrchFrontendNlbArn are used by the API Gateway (di-authentication-api) to define the NLB integration and VPC Link
+  OrchFrontendNlbDnsName:
+    Description: The DNS Name of the Orchestration Frontend NLB
+    Value: !GetAtt OrchFrontendNlb.DNSName
+
+  OrchFrontendNlbArn:
+    Description: The ARN of the Orchestration Frontend NLB
+    Value: !Ref OrchFrontendNlb
+

--- a/infrastructure/sandpit/ecs/template.yaml
+++ b/infrastructure/sandpit/ecs/template.yaml
@@ -180,16 +180,16 @@ Resources:
         - IpProtocol: "tcp"
           FromPort: 80
           ToPort: 80
-          CidrIp: "0.0.0.0/0"
+          CidrIp: "10.0.0.0/16"
         - IpProtocol: "tcp"
-          FromPort: 443
-          ToPort: 443
-          CidrIp: "0.0.0.0/0"
+          FromPort: 3000
+          ToPort: 3000
+          CidrIp: "10.0.0.0/16"
       SecurityGroupEgress:
         - IpProtocol: "-1"
-          FromPort: 0
-          ToPort: 65535
-          CidrIp: "0.0.0.0/0"
+          FromPort: 3000
+          ToPort: 3000
+          CidrIp: "10.0.0.0/16"
 
   OrchFrontendNlbSecurityGroup:
     Type: "AWS::EC2::SecurityGroup"
@@ -201,15 +201,11 @@ Resources:
           FromPort: 80
           ToPort: 80
           CidrIp: "0.0.0.0/0"
-        - IpProtocol: "tcp"
-          FromPort: 443
-          ToPort: 443
-          CidrIp: "0.0.0.0/0"
       SecurityGroupEgress:
         - IpProtocol: "-1"
-          FromPort: 0
-          ToPort: 65535
-          CidrIp: "0.0.0.0/0"
+          FromPort: 80
+          ToPort: 80
+          SourceSecurityGroupId: !Ref OrchFrontendAlbSecurityGroup
 
 Outputs:
   # OrchFrontendNlbDnsName and OrchFrontendNlbArn are used by the API Gateway (di-authentication-api) to define the NLB integration and VPC Link

--- a/infrastructure/sandpit/parameters.json
+++ b/infrastructure/sandpit/parameters.json
@@ -1,6 +1,6 @@
 [
   {
-    "ParameterKey": "Enviroment",
+    "ParameterKey": "Environment",
     "ParameterValue": "sandpit"
   },
   {

--- a/src/app.ts
+++ b/src/app.ts
@@ -22,6 +22,10 @@ const APP_VIEWS = [
 async function createApp(): Promise<express.Application> {
   const app: express.Application = express();
 
+  app.get("/health", (req, res) => {
+    res.status(200).send("OK");
+  });
+
   app.use(noCacheMiddleware);
 
   app.use(


### PR DESCRIPTION
## What?

- Add a Network Load Balancer (NLB) and an Application Load Balancer (ALB) to the Orchestration frontend.
- Add a route to the app for the ALB to check the health of ECS tasks.

## Why?

- Originally the idea was to have `API Gateway --> ALB --> ECS`, but API Gateway [does not support](https://repost.aws/knowledge-center/api-gateway-application-load-balancers) integration with a private ALB. 
- To get around this problem a VPC Link and NLB were added so the architecture is now `API Gateway --> VPC Link --> NLB --> ALB --> ECS`

## Related PRs
[ATO-181](https://github.com/govuk-one-login/authentication-api/pull/3566) sets up the API Gateway integration and VPC Link to the Orchestration frontend NLB.


[ATO-181]: https://govukverify.atlassian.net/browse/ATO-181?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ