### PR TITLE
ATO-214: Start new ECS task after deploying to ECR

### DIFF
--- a/deploy-sandpit.sh
+++ b/deploy-sandpit.sh
@@ -12,7 +12,7 @@ generate_ecr_credentials() {
 }
 
 build_and_tag_docker_image() {
-    echo "Building image..."
+    echo "Building Docker image..."
     docker build --platform=linux/amd64 -t "${REPO_NAME}" .
     echo "Tagging image..."
     docker tag "${REPO_NAME}:latest" "${REPO_URL}:${IMAGE_TAG}"
@@ -21,7 +21,7 @@ build_and_tag_docker_image() {
 update_ecs_template() {
     pushd "./infrastructure/sandpit/ecs"
     if grep -q "CONTAINER-IMAGE-PLACEHOLDER" template.yaml; then
-        echo "Replacing \"CONTAINER-IMAGE-PLACEHOLDER\" with ECR image ref"
+        echo "Replacing \"CONTAINER-IMAGE-PLACEHOLDER\" with ECR image ref..."
         cp template.yaml template_tmp.yaml
         sed -i '' "s|CONTAINER-IMAGE-PLACEHOLDER|$REPO_URL:$IMAGE_TAG|" template_tmp.yaml
     else
@@ -35,7 +35,7 @@ deploy_to_ecs() {
     pushd "./infrastructure/sandpit/ecs"
     parameters=$(cat ../parameters.json | jq -r '.[] | "\(.ParameterKey)=\(.ParameterValue)"')
     echo ${parameters}
-    echo "Deploying ECS"
+    echo "Deploying to ECS..."
     sam build
     sam deploy --stack-name sandpit-orch-frontend --template-file template_tmp.yaml --parameter-overrides $parameters --no-fail-on-empty-changeset --capabilities CAPABILITY_NAMED_IAM
     rm template_tmp.yaml
@@ -43,7 +43,7 @@ deploy_to_ecs() {
 }
 
 update_ecs_service() {
-    echo "Updating service"
+    echo "Updating service..."
     aws ecs update-service --cluster sandpit-orch-app-cluster --service sandpit-orch-frontend-ecs-service --force-new-deployment --no-cli-pager
 }
 

--- a/deploy-sandpit.sh
+++ b/deploy-sandpit.sh
@@ -1,34 +1,54 @@
+#!/bin/bash
+
 REPO_NAME="sandpit-orch-frontend-image-repository"
 REPO_URL="761723964695.dkr.ecr.eu-west-2.amazonaws.com/sandpit-orch-frontend-image-repository"
 IMAGE_TAG=latest
 
 set -eu
-parameters=$( cat ./infrastructure/sandpit/parameters.json | jq -r '.[] | "\(.ParameterKey)=\(.ParameterValue)"' )
 
-echo "Generating temporary ECR credentials..."
-aws ecr get-login-password | docker login --username AWS --password-stdin "${REPO_URL}"
+generate_ecr_credentials() {
+    echo "Generating temporary ECR credentials..."
+    aws ecr get-login-password | docker login --username AWS --password-stdin "${REPO_URL}"
+}
 
-echo "Building image..."
-docker build --platform=linux/amd64 -t "${REPO_NAME}" .
-echo "Tagging image..."
-docker tag "${REPO_NAME}:latest" "${REPO_URL}:${IMAGE_TAG}"
-echo "Pushing image..."
-docker push "${REPO_URL}:${IMAGE_TAG}"
+build_and_tag_docker_image() {
+    echo "Building image..."
+    docker build --platform=linux/amd64 -t "${REPO_NAME}" .
+    echo "Tagging image..."
+    docker tag "${REPO_NAME}:latest" "${REPO_URL}:${IMAGE_TAG}"
+}
 
-pushd "./infrastructure/sandpit/ecs"
-if grep -q "CONTAINER-IMAGE-PLACEHOLDER" template.yaml; then
-    echo "Replacing \"CONTAINER-IMAGE-PLACEHOLDER\" with ECR image ref"
-    cp template.yaml template_tmp.yaml
-    sed -i '' "s|CONTAINER-IMAGE-PLACEHOLDER|$REPO_URL:$IMAGE_TAG|" template_tmp.yaml
-else
-    echo "ERROR: Image placeholder text \"CONTAINER-IMAGE-PLACEHOLDER\" not found"
-    exit 1
-fi
-echo ${parameters}
-echo "Deploying ECS"
-sam build
-sam deploy --stack-name sandpit-orch-frontend --template-file template_tmp.yaml --parameter-overrides $parameters --no-fail-on-empty-changeset --capabilities CAPABILITY_NAMED_IAM
-echo "Updating service"
-aws ecs update-service --cluster sandpit-orch-app-cluster --service sandpit-orch-frontend-ecs-service --force-new-deployment --no-cli-pager
-rm template_tmp.yaml
-popd
+update_ecs_template() {
+    pushd "./infrastructure/sandpit/ecs"
+    if grep -q "CONTAINER-IMAGE-PLACEHOLDER" template.yaml; then
+        echo "Replacing \"CONTAINER-IMAGE-PLACEHOLDER\" with ECR image ref"
+        cp template.yaml template_tmp.yaml
+        sed -i '' "s|CONTAINER-IMAGE-PLACEHOLDER|$REPO_URL:$IMAGE_TAG|" template_tmp.yaml
+    else
+        echo "ERROR: Image placeholder text \"CONTAINER-IMAGE-PLACEHOLDER\" not found"
+        exit 1
+    fi
+    popd
+}
+
+deploy_to_ecs() {
+    pushd "./infrastructure/sandpit/ecs"
+    parameters=$(cat ../parameters.json | jq -r '.[] | "\(.ParameterKey)=\(.ParameterValue)"')
+    echo ${parameters}
+    echo "Deploying ECS"
+    sam build
+    sam deploy --stack-name sandpit-orch-frontend --template-file template_tmp.yaml --parameter-overrides $parameters --no-fail-on-empty-changeset --capabilities CAPABILITY_NAMED_IAM
+    rm template_tmp.yaml
+    popd
+}
+
+update_ecs_service() {
+    echo "Updating service"
+    aws ecs update-service --cluster sandpit-orch-app-cluster --service sandpit-orch-frontend-ecs-service --force-new-deployment --no-cli-pager
+}
+
+generate_ecr_credentials
+build_and_tag_docker_image
+update_ecs_template
+deploy_to_ecs
+update_ecs_service

--- a/deploy-sandpit.sh
+++ b/deploy-sandpit.sh
@@ -20,4 +20,6 @@ echo ${parameters}
 echo "Deploying ECS"
 sam build
 sam deploy --stack-name sandpit-orch-frontend --template-file template.yaml --parameter-overrides $parameters --no-fail-on-empty-changeset --capabilities CAPABILITY_NAMED_IAM
+echo "Updating service"
+aws ecs update-service --cluster sandpit-orch-app-cluster --service sandpit-orch-frontend-ecs-service --force-new-deployment --no-cli-pager
 popd

--- a/deploy-sandpit.sh
+++ b/deploy-sandpit.sh
@@ -16,10 +16,19 @@ echo "Pushing image..."
 docker push "${REPO_URL}:${IMAGE_TAG}"
 
 pushd "./infrastructure/sandpit/ecs"
+if grep -q "CONTAINER-IMAGE-PLACEHOLDER" template.yaml; then
+    echo "Replacing \"CONTAINER-IMAGE-PLACEHOLDER\" with ECR image ref"
+    cp template.yaml template_tmp.yaml
+    sed -i '' "s|CONTAINER-IMAGE-PLACEHOLDER|$REPO_URL:$IMAGE_TAG|" template_tmp.yaml
+else
+    echo "ERROR: Image placeholder text \"CONTAINER-IMAGE-PLACEHOLDER\" not found"
+    exit 1
+fi
 echo ${parameters}
 echo "Deploying ECS"
 sam build
-sam deploy --stack-name sandpit-orch-frontend --template-file template.yaml --parameter-overrides $parameters --no-fail-on-empty-changeset --capabilities CAPABILITY_NAMED_IAM
+sam deploy --stack-name sandpit-orch-frontend --template-file template_tmp.yaml --parameter-overrides $parameters --no-fail-on-empty-changeset --capabilities CAPABILITY_NAMED_IAM
 echo "Updating service"
 aws ecs update-service --cluster sandpit-orch-app-cluster --service sandpit-orch-frontend-ecs-service --force-new-deployment --no-cli-pager
+rm template_tmp.yaml
 popd

--- a/infrastructure/sandpit/ecs/template.yaml
+++ b/infrastructure/sandpit/ecs/template.yaml
@@ -119,7 +119,7 @@ Resources:
       ExecutionRoleArn: !GetAtt OrchFrontendECSExecutionRole.Arn
       ContainerDefinitions:
         - Name: sandpit-orch-frontend-image
-          Image: !Sub ${AWSAccount}.dkr.ecr.${Region}.amazonaws.com/sandpit-orch-frontend-image-repository:latest
+          Image: CONTAINER-IMAGE-PLACEHOLDER
           PortMappings:
             - ContainerPort: 3000
           LogConfiguration:


### PR DESCRIPTION
## What?

Start new ECS task after deploying to ECR, and stop old task. The new and old tasks run simultaneously for a short time to ensure zero downtime.

Use CONTAINER-IMAGE-PLACEHOLDER as ECR image reference, and modify deploy-sandpit.sh to be able to parse that.

## Why?

Previously the new task had to be started manually.

CONTAINER-IMAGE-PLACEHOLDER is used in the [pipeline script to push to ECR](https://github.com/govuk-one-login/devplatform-upload-action-ecr/blob/main/scripts/build-tag-push-ecr.sh).