### PR TITLE
ATO-266: Remove node version from package.json

### DIFF
--- a/.github/workflows/run-checks.yml
+++ b/.github/workflows/run-checks.yml
@@ -17,7 +17,7 @@ jobs:
 
       - name: Get Node.js version
         run: |
-          version=$(grep -oP '(?<="node": ")[^"]*' package.json)
+          version=$(grep -oP -m1 '(?<=node:).*(?= as)' Dockerfile)
           echo "NODE_VERSION=$version" >> $GITHUB_ENV
 
       - name: Using Node.js ${{ env.NODE_VERSION }}
@@ -25,6 +25,9 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
+
+      - name: Get NPM version
+        run: echo "Using npm:$(npm -version)"
 
       - name: Cache NPM dependencies
         uses: actions/cache@v3
@@ -49,7 +52,7 @@ jobs:
 
       - name: Get Node.js version
         run: |
-          version=$(grep -oP '(?<="node": ")[^"]*' package.json)
+          version=$(grep -oP -m1 '(?<=node:).*(?= as)' Dockerfile)
           echo "NODE_VERSION=$version" >> $GITHUB_ENV
 
       - name: Using Node.js ${{ env.NODE_VERSION }}
@@ -57,6 +60,9 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
+
+      - name: Get NPM version
+        run: echo "Using npm:$(npm -version)"
 
       - name: Cache NPM dependencies
         uses: actions/cache@v3
@@ -77,7 +83,7 @@ jobs:
 
       - name: Get Node.js version
         run: |
-          version=$(grep -oP '(?<="node": ")[^"]*' package.json)
+          version=$(grep -oP -m1 '(?<=node:).*(?= as)' Dockerfile)
           echo "NODE_VERSION=$version" >> $GITHUB_ENV
 
       - name: Using Node.js ${{ env.NODE_VERSION }}
@@ -85,6 +91,9 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
+
+      - name: Get NPM version
+        run: echo "Using npm:$(npm -version)"
 
       - name: Cache NPM dependencies
         uses: actions/cache@v3
@@ -105,7 +114,7 @@ jobs:
 
       - name: Get Node.js version
         run: |
-          version=$(grep -oP '(?<="node": ")[^"]*' package.json)
+          version=$(grep -oP -m1 '(?<=node:).*(?= as)' Dockerfile)
           echo "NODE_VERSION=$version" >> $GITHUB_ENV
 
       - name: Using Node.js ${{ env.NODE_VERSION }}
@@ -113,6 +122,9 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
+
+      - name: Get NPM version
+        run: echo "Using npm:$(npm -version)"
 
       - name: Cache NPM dependencies
         uses: actions/cache@v3
@@ -123,6 +135,7 @@ jobs:
 
       - name: Run unit tests
         run: npm run test:unit
+
       - name: Run integration tests
         run: npm run test:integration
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ You can run the app in Docker using:
 
 ### Running app locally:
 
+_Please ensure you are using the correct node version locally (Found in Dockerfile)_
+
 #### Build
 
 > To build the app

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,9 +54,6 @@
         "ts-node": "^10.9.2",
         "typescript": "^5.3.3",
         "uglifyjs": "^2.4.11"
-      },
-      "engines": {
-        "node": "20.9"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -4,9 +4,6 @@
   "description": "",
   "author": "",
   "license": "ISC",
-  "engines": {
-    "node": "20.9"
-  },
   "scripts": {
     "build": "npm run build-sass && npx tsc && npm run copy-assets",
     "build-sass": "rm -rf dist/public/style.css && sass --load-path=node_modules/govuk-frontend/dist/govuk --no-source-map --quiet-deps src/assets/scss/application.scss:dist/public/style.css --style compressed",


### PR DESCRIPTION
## What?
- Remove node version from package.json
- Update gitub actions to use Dockerfile
- Add npm version to github actions output

## Why?
- This version is not updated via Dependabot and is often several versions behind the version we are running.
- Making Dockerfile single source of truth for node version will reduce confusion.
- Logging npm version on github actions makes it easy to compare to local instances.