### PR TITLE
ATO-351: Upgrade to govuk-frontend 4.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "axios": "^1.6.7",
         "cookie-parser": "^1.4.6",
         "express": "^4.18.2",
-        "govuk-frontend": "^4.3.1",
+        "govuk-frontend": "^4.8.0",
         "i18next": "^23.8.2",
         "i18next-fs-backend": "^2.3.1",
         "i18next-http-middleware": "^3.5.0",
@@ -2994,9 +2994,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.7.0.tgz",
-      "integrity": "sha512-0OsdCusF5qvLWwKziU8zqxiC0nq6WP0ZQuw51ymZ/1V0tO71oIKMlSLN2S9bm8RcEGSoidPt2A34gKxePrLjvg==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.8.0.tgz",
+      "integrity": "sha512-NOmPJxL8IYq1HSNHYKx9XY2LLTxuwb+IFASiGQO4sgJ8K7AG66SlSeqARrcetevV8zOf+i1z+MbJJ2O7//OxAw==",
       "engines": {
         "node": ">= 4.2.0"
       }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "axios": "^1.6.7",
     "cookie-parser": "^1.4.6",
     "express": "^4.18.2",
-    "govuk-frontend": "^4.3.1",
+    "govuk-frontend": "^4.8.0",
     "i18next": "^23.8.2",
     "i18next-fs-backend": "^2.3.1",
     "i18next-http-middleware": "^3.5.0",


### PR DESCRIPTION
## What?

Upgrade to govuk-frontend v4.8

## Why?

Required to update crown logo.

## Related PRs

[ATO-349](https://govukverify.atlassian.net/jira/software/c/projects/ATO/boards/390?selectedIssue=ATO-349)


[ATO-349]: https://govukverify.atlassian.net/browse/ATO-349?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ