### PR TITLE
BAU: Fix ALB target group health check path

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -166,7 +166,7 @@ Resources:
       TargetType: ip
       HealthCheckProtocol: HTTP
       HealthCheckPort: "traffic-port"
-      HealthCheckPath: "/orch-frontend/health"
+      HealthCheckPath: "/health"
       HealthCheckIntervalSeconds: 30
       HealthyThresholdCount: 2
       UnhealthyThresholdCount: 2


### PR DESCRIPTION
## What?

Deploying to sandpit was failing when `HealthCheckPath: "/orch-frontend/health"`. This was because the health check was failing with status 404 (not found). 
Note that the path was originally set up with `HeathCheckPath: "/health"` but this was changed in [this commit](https://github.com/govuk-one-login/orchestration-frontend/pull/67/commits/2a30c87949687f3bfef121141aa5f3ebc31524fa#:~:text=%3A%20%22/-,orch,-%2Dfrontend/)

## Related PRs

[PR where target group and health check were first set up](https://github.com/govuk-one-login/orchestration-frontend/pull/38)
[PR where health check path was changed](https://github.com/govuk-one-login/orchestration-frontend/pull/67)

## Question
Why were deployments to build not failing when  `HealthCheckPath: "/orch-frontend/health"`?
