### PR TITLE
Revert "BAU: Fix ALB target group health check path"

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -166,7 +166,7 @@ Resources:
       TargetType: ip
       HealthCheckProtocol: HTTP
       HealthCheckPort: "traffic-port"
-      HealthCheckPath: "/health"
+      HealthCheckPath: "/orch-frontend/health"
       HealthCheckIntervalSeconds: 30
       HealthyThresholdCount: 2
       UnhealthyThresholdCount: 2


### PR DESCRIPTION
Reverts govuk-one-login/orchestration-frontend#219

Caused ECS health checks to fail in build