### PR TITLE
ATO-457: Fix deploying to orch frontend sandpit

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -29,6 +29,8 @@ Conditions:
     !Not [ !Equals [ none, !Ref PermissionsBoundary ] ]
   IsProd:
     !Equals [ production, !Ref Environment ]
+  OidcApiGatewayIntegrationEnabled:
+    !Equals [ sandpit, !Ref Environment ]
 
 Mappings:
   EnvironmentConfiguration:
@@ -166,7 +168,10 @@ Resources:
       TargetType: ip
       HealthCheckProtocol: HTTP
       HealthCheckPort: "traffic-port"
-      HealthCheckPath: "/orch-frontend/health"
+      HealthCheckPath: !If
+        - OidcApiGatewayIntegrationEnabled
+        - "/health"
+        - "/orch-frontend/health"
       HealthCheckIntervalSeconds: 30
       HealthyThresholdCount: 2
       UnhealthyThresholdCount: 2


### PR DESCRIPTION
## What?

- Set health check path to `/health` in envs where integration with OIDC API is enabled, and `/orch-frontend/health` in all other envs. This is controlled by a flag called `OidcApiGatewayIntegrationEnabled` which means the same as  `orch_frontend_api_gateway_integration_enabled` in OIDC API.
- I will add some information in OIDC API to ensure that when `orch_frontend_api_gateway_integration_enabled` is enabled for a new env, the config here is updated so that `OidcApiGatewayIntegrationEnabled` is true for that env.

## Why?

- In OIDC API a VPC link is set up to the orchestration frontend. This config adds `/orch-frontend` path part to requests. It is currently feature flagged and only enabled in sandpit. This means that in order to deploy successfully, the health check path has to be `/health` in sandpit but `/orch-frontend/health` in all other envs.


