### PR TITLE
SW-307: Set log retention to 30 days

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -72,7 +72,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /ecs/${Environment}-orch-frontend
-
+      RetentionInDays: 30
 
   OrchFrontendECSSecretsManagerAccessManagedPolicy:
     Type: AWS::IAM::ManagedPolicy


### PR DESCRIPTION
## What?

[SW-307](https://govukverify.atlassian.net/browse/SW-307) Set log retention to 30 days 

## Why?

Currently any log retention that is set under 30 days will be set to 30 by a Lambda attached to the LZA Lambda run - see [INCIDEN-627](https://govukverify.atlassian.net/browse/INCIDEN-627)

## Change have been demonstrated

Changes to the user interface or content should be demonstrated to Content Design and Interaction Design before being merged. This is to ensure they can make any necessary changes to Figma.

- [ ] Changes to the user interface have been demonstrated

Delete this section if the PR does not change the UI.

## Performance Analysis have been informed of the change

- [ ] Performance Analysis have been informed of the change

## Related PRs

Please include links to PRs in other repositories relevant to this PR.
Delete this section if not needed.


[SW-307]: https://govukverify.atlassian.net/browse/SW-307?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[INCIDEN-627]: https://govukverify.atlassian.net/browse/INCIDEN-627?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ