### PR TITLE
ATO-1864: Update Orch frontend readme with deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # orchestration-frontend
 
+This repository has now been archived. Due to UCD guidance, the spinner is being removed from identity journeys, and 
+therefore there is no longer a requirement for a frontend in the Orchestration component.
+
 ## Requirements
 
 You will need the AWS CLI. You can install it via:


### PR DESCRIPTION
## What?

Notice for deprecating orch frontend
## Why?

This frontend is no longer required
## Change have been demonstrated

Changes to the user interface or content should be demonstrated to Content Design and Interaction Design before being merged. This is to ensure they can make any necessary changes to Figma.

- [ ] Changes to the user interface have been demonstrated

Delete this section if the PR does not change the UI.

## Performance Analysis have been informed of the change

- [ ] Performance Analysis have been informed of the change

## Related PRs

Please include links to PRs in other repositories relevant to this PR.
Delete this section if not needed.
